### PR TITLE
Modifying the tests and bug fixes

### DIFF
--- a/api-quiz/Controllers/PlayerController.cs
+++ b/api-quiz/Controllers/PlayerController.cs
@@ -9,7 +9,7 @@ namespace APIQuiz.Controllers
     [Route("apiQuiz/[controller]")]
     public class PlayerController : ControllerBase
     {
-        private readonly PlayerService playerService = new();
+        private static PlayerService playerService = new();
         public PlayerController()
         {
         }

--- a/api-quiz/api-quiz.sln
+++ b/api-quiz/api-quiz.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.31410.357
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "api-quiz", "api-quiz.csproj", "{2814819A-27A2-483C-BEAE-CFF09BFA23EC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api-quizTests", "..\api-quizTests\api-quizTests.csproj", "{7E99DD49-7B9A-43A2-9D6E-1938769BC503}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "api-quizTests", "..\api-quizTests\api-quizTests.csproj", "{7E99DD49-7B9A-43A2-9D6E-1938769BC503}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/api-quizTests/Controllers/PlayerControllerTests.cs
+++ b/api-quizTests/Controllers/PlayerControllerTests.cs
@@ -13,6 +13,11 @@ namespace APIQuiz.Controllers.Tests
 {
     public class PlayerControllerTests
     {
+        private PlayerController playerController;
+        public PlayerControllerTests()
+        {
+            playerController = new();
+        }
 
         [Theory]
         [InlineData("")]
@@ -21,7 +26,6 @@ namespace APIQuiz.Controllers.Tests
         [Trait("Controller", "CreateNewPlayer")]
         public void CreateNewPlayer_InvalidName_Test(string name)
         {
-            PlayerController playerController = new() { };
             Player player = new() { Name = name};
 
             var createNewPlayerResult = playerController.CreateNewPlayer(player);
@@ -38,7 +42,6 @@ namespace APIQuiz.Controllers.Tests
         [Trait("Controller", "CreateNewPlayer")]
         public void CreateNewPlayer_Valid_Test(string name)
         {
-            PlayerController playerController = new() { };
             Player player = new() { Name = name };
 
             var createNewPlayerResult = playerController.CreateNewPlayer(player);
@@ -54,8 +57,6 @@ namespace APIQuiz.Controllers.Tests
         [Trait("Controller", "GetPlayerById")]
         public void GetPlayerById_Invalid_Test(int playerListSize, int id)
         {
-            PlayerController playerController = new() { };
-
             for (int i = 0; i < playerListSize; i++)
             {
                 Player player = new() { Name = "new_player_name" };
@@ -76,8 +77,6 @@ namespace APIQuiz.Controllers.Tests
         [Trait("Controller", "GetPlayerById")]
         public void GetPlayerById_Valid_Test(int playerListSize, int id)
         {
-            PlayerController playerController = new() { };
-
             for (int i = 0; i < playerListSize; i++)
             {
                 Player player = new() { Name = "new_player_name" };
@@ -95,8 +94,6 @@ namespace APIQuiz.Controllers.Tests
         [Trait("Controller", "UpdatePlayerById")]
         public void UpdatePlayerById_Valid_Test()
         {
-            PlayerController playerController = new() { };
-
             Player player = new() { Name = "old_player_name" };
             playerController.CreateNewPlayer(player);
 
@@ -112,8 +109,6 @@ namespace APIQuiz.Controllers.Tests
         [Trait("Controller", "UpdatePlayerById")]
         public void UpdatePlayerById_InvalidId_Test()
         {
-            PlayerController playerController = new() { };
-
             Player player = new() { Name = "old_player_name" };
             playerController.CreateNewPlayer(player);
 
@@ -132,8 +127,6 @@ namespace APIQuiz.Controllers.Tests
         [Trait("Controller", "UpdatePlayerById")]
         public void UpdatePlayerById_InvalidName_Test(string name)
         {
-            PlayerController playerController = new() { };
-
             Player player = new() { Name = "old_player_name" };
             playerController.CreateNewPlayer(player);
 
@@ -149,8 +142,6 @@ namespace APIQuiz.Controllers.Tests
         [Trait("Controller", "UpdatePlayerById")]
         public void UpdatePlayerById_InvalidScore_Test()
         {
-            PlayerController playerController = new() { };
-
             Player player = new() { Name = "old_player_name" };
             playerController.CreateNewPlayer(player);
 
@@ -166,8 +157,6 @@ namespace APIQuiz.Controllers.Tests
         [Trait("Controller", "UpdatePlayerById")]
         public void UpdatePlayerById_InvalidPlayer_Test()
         {
-            PlayerController playerController = new() { };
-
             Player player = new() { Name = "old_player_name" };
             playerController.CreateNewPlayer(player);
 
@@ -183,8 +172,6 @@ namespace APIQuiz.Controllers.Tests
         [Trait("Controller", "DeletePlayerById")]
         public void DeletePlayerById_Valid_Test()
         {
-            PlayerController playerController = new() { };
-
             Player player = new() { Name = "new_player_name" };
             playerController.CreateNewPlayer(player);
 
@@ -199,8 +186,6 @@ namespace APIQuiz.Controllers.Tests
         [Trait("Controller", "DeletePlayerById")]
         public void DeletePlayerById_InvalidPlayer_Test()
         {
-            PlayerController playerController = new() { };
-
             Player player = new() { Name = "new_player_name" };
             playerController.CreateNewPlayer(player);
 

--- a/api-quizTests/Services/PlayerServiceTests.cs
+++ b/api-quizTests/Services/PlayerServiceTests.cs
@@ -11,6 +11,13 @@ namespace APIQuiz.Services.Tests
 {
     public class PlayerServiceTests
     {
+        private PlayerService playerService;
+
+        public PlayerServiceTests()
+        {
+            playerService = new();
+        }
+
         [Theory]
         [InlineData(1)]
         [InlineData(2)]
@@ -18,8 +25,6 @@ namespace APIQuiz.Services.Tests
         [Trait("PlayerService", "GetAll")]
         public void GetAll_Simple_Test(int playerListSize)
         {
-            PlayerService playerService = new();
-
             for (int i = 0; i < playerListSize; i++)
             {
                 Player player = new() { Name = "new_player_name" };
@@ -36,8 +41,6 @@ namespace APIQuiz.Services.Tests
         [Trait("PlayerService", "Get")]
         public void Get_ValidId_Test(int playerListSize, int id)
         {
-            PlayerService playerService = new();
-
             for (int i = 0; i < playerListSize; i++)
             {
                 Player player = new() { Name = "new_player_name" };
@@ -55,8 +58,6 @@ namespace APIQuiz.Services.Tests
         [Trait("PlayerService", "Get")]
         public void Get_InvalidId_Test(int playerListSize, int id)
         {
-            PlayerService playerService = new();
-
             for (int i = 0; i < playerListSize; i++)
             {
                 Player player = new() { Name = "new_player_name" };
@@ -71,8 +72,6 @@ namespace APIQuiz.Services.Tests
         [Trait("PlayerService", "Create")]
         public void Create_Simple_Test()
         {
-            PlayerService playerService = new();
-
             Player player = new() { Name = "new_player_name" };
             playerService.Create(player);
 
@@ -88,8 +87,6 @@ namespace APIQuiz.Services.Tests
         [Trait("PlayerService", "Create")]
         public void Create_InvalidId_Test()
         {
-            PlayerService playerService = new();
-
             Player player = new() { Id = 10, Name = "new_player_name" };
             playerService.Create(player);
 
@@ -102,8 +99,6 @@ namespace APIQuiz.Services.Tests
         [Trait("PlayerService", "Create")]
         public void Create_InvalidScore_Test()
         {
-            PlayerService playerService = new();
-
             Player player = new() { Name = "new_player_name", Score = 100 };
             playerService.Create(player);
 
@@ -116,8 +111,6 @@ namespace APIQuiz.Services.Tests
         [Trait("PlayerService", "Delete")]
         public void Delete_Simple_Test()
         {
-            PlayerService playerService = new();
-
             Player player = new() { Name = "new_player_name" };
             playerService.Create(player);
 
@@ -134,8 +127,6 @@ namespace APIQuiz.Services.Tests
         [Trait("PlayerService", "Update")]
         public void Update_Simple_Test()
         {
-            PlayerService playerService = new();
-
             Player player = new() { Name = "old_player_name" };
             playerService.Create(player);
 
@@ -156,8 +147,6 @@ namespace APIQuiz.Services.Tests
         [Trait("PlayerService", "Exists")]
         public void Exists_True_Test(int playerListSize, int id)
         {
-            PlayerService playerService = new();
-
             for (int i = 0; i < playerListSize; i++)
             {
                 Player player = new() { Name = "new_player_name" };
@@ -173,8 +162,6 @@ namespace APIQuiz.Services.Tests
         [Trait("PlayerService", "Exists")]
         public void Exists_False_Test(int playerListSize, int id)
         {
-            PlayerService playerService = new();
-
             for (int i = 0; i < playerListSize; i++)
             {
                 Player player = new() { Name = "new_player_name" };


### PR DESCRIPTION
The last merge caused a bug in which the user wasn't able to add a player because new instances of the PlayerService class would be created, never using the created objects.